### PR TITLE
Restructure constants

### DIFF
--- a/TPTBox/__init__.py
+++ b/TPTBox/__init__.py
@@ -22,7 +22,7 @@ from TPTBox.core.nii_wrapper import (
 )
 from TPTBox.core.poi import (
     POI,
-    Ax_Codes,
+    AX_CODES,
     POI_Reference,
     VertebraCentroids,
     calc_centroids,
@@ -32,7 +32,7 @@ from TPTBox.core.poi import (
 from TPTBox.core.poi import load_poi
 from TPTBox.core.poi import load_poi as load_centroids
 from TPTBox.core.poi_global import POI_Global
-from TPTBox.core.vert_constants import Location, Zooms, v_idx2name, v_idx_order, v_name2idx
+from TPTBox.core.vert_constants import Location, ZOOMS, v_idx2name, v_idx_order, v_name2idx
 
 # Logger
 from TPTBox.logger import Log_Type, Logger, Logger_Interface, Print_Logger, String_Logger

--- a/TPTBox/core/__init__.py
+++ b/TPTBox/core/__init__.py
@@ -8,8 +8,8 @@ from .bids_files import BIDS_FILE, BIDS_Family, BIDS_Global_info, Searchquery, S
 # NII
 from .nii_wrapper import NII, Image_Reference, Interpolateable_Image_Reference, to_nii, to_nii_interpolateable, to_nii_optional, to_nii_seg
 from .poi import (
+    AX_CODES,
     POI,
-    Ax_Codes,
     POI_Reference,
     VertebraCentroids,
     calc_centroids,
@@ -18,4 +18,4 @@ from .poi import (
     load_poi,
 )
 from .poi_global import POI_Global
-from .vert_constants import Location, Zooms, v_idx2name, v_idx_order, v_name2idx
+from .vert_constants import ZOOMS, Location, v_idx2name, v_idx_order, v_name2idx

--- a/TPTBox/core/bids_constants.py
+++ b/TPTBox/core/bids_constants.py
@@ -33,6 +33,7 @@ formats = [
     "PWI",  # Perfusion weighted imaging
     "DTI",  # Diffusion tensor imaging
     "radiomics",
+    "MPR",  # Rapid gradient-echo (MP RAGE) sampling
 ]
 formats_relaxed = [*formats, "t2", "t1", "t2c", "t1c", "cta", "mr", "snapshot", "t1dixon"]
 # Recommended writing style: T1c, T2c; This list is not official and can be extended.

--- a/TPTBox/core/bids_files.py
+++ b/TPTBox/core/bids_files.py
@@ -544,6 +544,7 @@ class BIDS_FILE:
         additional_folder: str | None = None,
         dataset_path: str | None = None,
         make_parent=True,
+        no_sorting_mode: bool = False,
         non_strict_mode: bool = False,
     ) -> Path:
         """
@@ -569,6 +570,8 @@ class BIDS_FILE:
             additional_folder (str | None, optional): add an additional folder towards path. Defaults to None.
 
             dataset_path (str | None, optional): Override the dataset_path. Defaults to None.
+
+            no_sorting_mode (bool): If true, will keep the order of the origin nii. Defaults to False
 
         Returns:
             _type_: _description_
@@ -624,12 +627,14 @@ class BIDS_FILE:
                     final_info[key] = value
                 # file_name += f"{key}-{value}_"
             # sort by order
-            entity_keys = list(entities_keys.keys())
-            keys_sorted = sorted(
-                final_info.keys(),
-                key=lambda x: entity_keys.index(x) if x in entity_keys else list(final_info.keys()).index(x) + len(entity_keys),
-            )
-            for key in keys_sorted:
+            keys_order = final_info.keys()
+            if not no_sorting_mode:
+                entity_keys = list(entities_keys.keys())
+                keys_order = sorted(
+                    final_info.keys(),
+                    key=lambda x: entity_keys.index(x) if x in entity_keys else list(final_info.keys()).index(x) + len(entity_keys),
+                )
+            for key in keys_order:
                 file_name += f"{key}-{final_info[key]}_"
             # End Info
             bids_format = bids_format if bids_format is not None else same_format
@@ -772,9 +777,9 @@ class BIDS_FILE:
         from TPTBox import load_centroids
 
         try:
-            cdt = load_centroids(self.file["json"])
-            if cdt.zoom is None or cdt.shape is None:
-                if nii is None:
+            ctd = load_centroids(self.file["json"])
+            if ctd.zoom is None or ctd.shape is None or ctd.rotation is None or ctd.origin is None or ctd.orientation is None:
+                if nii is None and "ctd.json" in str(self.file["json"]):
                     p = Path(str(self.file["json"]).replace("ctd.json", "msk.nii.gz"))
                     nii = p if p.exists() else nii
                 assert (
@@ -782,14 +787,14 @@ class BIDS_FILE:
                 ), "This file has no zoom info. Use open_ctd(self, nii) with a image reference (BIDS_FILE/PATH) with the same nii"
                 nii = TPTBox.to_nii(nii)
                 assert isinstance(nii, TPTBox.NII)
-                cdt.zoom = nii.zoom
-                cdt.shape = nii.shape
-                cdt.rotation = nii.rotation
-                cdt.origin = nii.origin
-                cdt.orientation = nii.orientation
+                ctd.zoom = nii.zoom
+                ctd.shape = nii.shape
+                ctd.rotation = nii.rotation
+                ctd.origin = nii.origin
+                ctd.orientation = nii.orientation
         except KeyError as e:
             raise ValueError(f"json not present. Found only {self.file.keys()}\t{self.file}\n\n{self}") from e
-        return cdt
+        return ctd
 
     def open_ctd(self, nii: TPTBox.Image_Reference | None = None):
         return self.open_poi(nii)

--- a/TPTBox/core/nii_wrapper.py
+++ b/TPTBox/core/nii_wrapper.py
@@ -16,6 +16,8 @@ from typing_extensions import Self
 from TPTBox.core.nii_wrapper_math import NII_Math
 from TPTBox.core.np_utils import (
     np_calc_boundary_mask,
+    np_calc_convex_hull,
+    np_calc_overlapping_labels,
     np_center_of_mass,
     np_connected_components,
     np_count_nonzero,
@@ -29,26 +31,30 @@ from TPTBox.core.np_utils import (
     np_unique_withoutzero,
     np_volume,
 )
-from TPTBox.core.vert_constants import Coordinate
+from TPTBox.core.vert_constants import COORDINATE
+from TPTBox.logger.log_file import Log_Type
 
 from . import bids_files
-from . import vert_constants as vc
-from .vert_constants import Sentinel
+from .vert_constants import (
+    AFFINE,
+    AX_CODES,
+    DIRECTIONS,
+    LABEL_MAP,
+    ORIGIN,
+    ROTATION,
+    SHAPE,
+    ZOOMS,
+    Location,
+    Sentinel,
+    _plane_dict,
+    _same_direction,
+    log,
+    logging,
+    v_name2idx,
+)
 
-AFFINE = np.ndarray
 _unpacked_nii = tuple[np.ndarray, AFFINE, nib.nifti1.Nifti1Header]
-log = vc.log
-Ax_Codes = vc.Ax_Codes
-logging = vc.logging
-v_name2idx = vc.v_name2idx
-Label_Map = vc.Label_Map
-Directions = vc.Directions
-plane_dict = vc.plane_dict
 _formatwarning = warnings.formatwarning
-Zooms = vc.Zooms
-SHAPE = vc.Triple | tuple[int, int, int]
-ORIGIN = vc.Triple
-ROTATION = vc.Rotation
 if TYPE_CHECKING:
     from TPTBox.core.poi import POI
 
@@ -261,12 +267,12 @@ class NII(NII_Math):
         self._unpack()
         self._aff = affine
     @property
-    def orientation(self) -> vc.Ax_Codes:
+    def orientation(self) -> AX_CODES:
         ort = nio.io_orientation(self.affine)
         return nio.ornt2axcodes(ort) # type: ignore
 
     @property
-    def zoom(self) -> Zooms:
+    def zoom(self) -> ZOOMS:
         rotation_zoom = self.affine[:3, :3]
         zoom = np.sqrt(np.sum(rotation_zoom * rotation_zoom, axis=0)) if self.__divergent else self.header.get_zooms()
 
@@ -293,7 +299,7 @@ class NII(NII_Math):
 
 
     @orientation.setter
-    def orientation(self, value: vc.Ax_Codes):
+    def orientation(self, value: AX_CODES):
         self.reorient_(value, verbose=False)
 
     @property
@@ -337,7 +343,7 @@ class NII(NII_Math):
             return self.get_seg_array()
         self._unpack()
         return self._arr.copy()
-    def set_array(self,arr:np.ndarray, inplace=False,verbose:vc.logging=False)-> Self:  # noqa: ARG002
+    def set_array(self,arr:np.ndarray, inplace=False,verbose:logging=False)-> Self:  # noqa: ARG002
         """Creates a NII where the array is replaces with the input array.
 
         Note: This function works "Out-of-place" by default, like all other methods.
@@ -373,7 +379,7 @@ class NII(NII_Math):
         else:
             return NII(nii,self.seg) # type: ignore
 
-    def set_array_(self,arr:np.ndarray,verbose:vc.logging=True):
+    def set_array_(self,arr:np.ndarray,verbose:logging=True):
         return self.set_array(arr,inplace=True,verbose=verbose)
     def set_dtype_(self,dtype:type|Literal['smallest_int'] = np.float32):
         if dtype == "smallest_int":
@@ -390,16 +396,16 @@ class NII(NII_Math):
             self.nii = Nifti1Image(self.get_array().astype(dtype),self.affine,self.header)
 
         return self
-    def global_to_local(self, x: vc.Coordinate):
+    def global_to_local(self, x: COORDINATE):
         a = self.rotation.T @ (np.array(x) - self.origin) / np.array(self.zoom)
         return tuple(round(float(v), 7) for v in a)
 
-    def local_to_global(self, x:  vc.Coordinate):
+    def local_to_global(self, x:  COORDINATE):
         a = self.rotation @ (np.array(x) * np.array(self.zoom)) + self.origin
         return tuple(round(float(v), 7) for v in a)
 
 
-    def reorient(self:Self, axcodes_to: vc.Ax_Codes = ("P", "I", "R"), verbose:vc.logging=False, inplace=False)-> Self:
+    def reorient(self:Self, axcodes_to: AX_CODES = ("P", "I", "R"), verbose:logging=False, inplace=False)-> Self:
         """
         Reorients the input Nifti image to the desired orientation, specified by the axis codes.
 
@@ -443,7 +449,7 @@ class NII(NII_Math):
             return self
 
         return NII(new_img, self.seg) # type: ignore
-    def reorient_(self:Self, axcodes_to: vc.Ax_Codes|None = ("P", "I", "R"), verbose:vc.logging=False) -> Self:
+    def reorient_(self:Self, axcodes_to: AX_CODES|None = ("P", "I", "R"), verbose:logging=False) -> Self:
         if axcodes_to is None:
             return self
         return self.reorient(axcodes_to=axcodes_to, verbose=verbose,inplace=True)
@@ -618,7 +624,7 @@ class NII(NII_Math):
             return self
         return self.copy(nii)
 
-    def rescale_and_reorient(self, axcodes_to=None, voxel_spacing=(-1, -1, -1), verbose:vc.logging=True, inplace=False,c_val:float|None=None,mode='constant'):
+    def rescale_and_reorient(self, axcodes_to=None, voxel_spacing=(-1, -1, -1), verbose:logging=True, inplace=False,c_val:float|None=None,mode='constant'):
 
         ## Resample and rotate and Save Tempfiles
         if axcodes_to is None:
@@ -629,15 +635,15 @@ class NII(NII_Math):
             curr = self.reorient(axcodes_to=axcodes_to, verbose=verbose, inplace=inplace)
         return curr.rescale(voxel_spacing=voxel_spacing, verbose=verbose, inplace=inplace,c_val=c_val,mode=mode)
 
-    def rescale_and_reorient_(self,axcodes_to=None, voxel_spacing=(-1, -1, -1),c_val:float|None=None,mode='constant', verbose:vc.logging=True):
+    def rescale_and_reorient_(self,axcodes_to=None, voxel_spacing=(-1, -1, -1),c_val:float|None=None,mode='constant', verbose:logging=True):
         return self.rescale_and_reorient(axcodes_to=axcodes_to,voxel_spacing=voxel_spacing,c_val=c_val,mode=mode,verbose=verbose,inplace=True)
 
-    def reorient_same_as(self, img_as: Nifti1Image | Self, verbose:vc.logging=False, inplace=False) -> Self:
-        axcodes_to: Ax_Codes = nio.ornt2axcodes(nio.io_orientation(img_as.affine)) # type: ignore
+    def reorient_same_as(self, img_as: Nifti1Image | Self, verbose:logging=False, inplace=False) -> Self:
+        axcodes_to: AX_CODES = nio.ornt2axcodes(nio.io_orientation(img_as.affine)) # type: ignore
         return self.reorient(axcodes_to=axcodes_to, verbose=verbose, inplace=inplace)
-    def reorient_same_as_(self, img_as: Nifti1Image | Self, verbose:vc.logging=False) -> Self:
+    def reorient_same_as_(self, img_as: Nifti1Image | Self, verbose:logging=False) -> Self:
         return self.reorient_same_as(img_as=img_as,verbose=verbose,inplace=True)
-    def rescale(self, voxel_spacing=(1, 1, 1), c_val:float|None=None, verbose:vc.logging=False, inplace=False,mode='constant',align_corners:bool=False):
+    def rescale(self, voxel_spacing=(1, 1, 1), c_val:float|None=None, verbose:logging=False, inplace=False,mode='constant',align_corners:bool=False):
         """
         Rescales the NIfTI image to a new voxel spacing.
 
@@ -680,10 +686,10 @@ class NII(NII_Math):
             return self
         return NII(new_img, self.seg,self.c_val)
 
-    def rescale_(self, voxel_spacing=(1, 1, 1), c_val:float|None=None, verbose:vc.logging=False,mode='constant'):
+    def rescale_(self, voxel_spacing=(1, 1, 1), c_val:float|None=None, verbose:logging=False,mode='constant'):
         return self.rescale( voxel_spacing=voxel_spacing, c_val=c_val, verbose=verbose,mode=mode, inplace=True)
 
-    def resample_from_to(self, to_vox_map:Image_Reference|Proxy, mode='constant', c_val=None, inplace = False,verbose:vc.logging=True,align_corners:bool=False):
+    def resample_from_to(self, to_vox_map:Image_Reference|Proxy, mode='constant', c_val=None, inplace = False,verbose:logging=True,align_corners:bool=False):
         """self will be resampled in coordinate of given other image. Adheres to global space not to local pixel space
         Args:
             to_vox_map (Image_Reference|Proxy): If object, has attributes shape giving input voxel shape, and affine giving mapping of input voxels to output space. If length 2 sequence, elements are (shape, affine) with same meaning as above. The affine is a (4, 4) array-like.\n
@@ -851,20 +857,20 @@ class NII(NII_Math):
         ix_max = np.array(zms == np.amax(zms))
         num_max = np_count_nonzero(ix_max)
         if num_max == 2:
-            plane = plane_dict[axc[~ix_max][0]]
+            plane = _plane_dict[axc[~ix_max][0]]
         elif num_max == 1:
-            plane = plane_dict[axc[ix_max][0]]
+            plane = _plane_dict[axc[ix_max][0]]
         else:
             plane = "iso"
         return plane
 
-    def get_axis(self,direction:Directions = "S"):
+    def get_axis(self,direction:DIRECTIONS = "S"):
         if direction not in self.orientation:
-            direction = vc.same_direction[direction]
+            direction = _same_direction[direction]
         return self.orientation.index(direction)
 
 
-    def erode_msk(self, mm: int = 5, labels: Sequence[int] | None = None, connectivity: int = 3, inplace=False,verbose:vc.logging=True):
+    def erode_msk(self, mm: int = 5, labels: Sequence[int] | None = None, connectivity: int = 3, inplace=False,verbose:logging=True):
         """
         Erodes the binary segmentation mask by the specified number of voxels.
 
@@ -932,7 +938,7 @@ class NII(NII_Math):
         return self.dilate_msk(mm=mm, labels=labels, connectivity=connectivity, mask=mask, inplace=True, verbose=verbose)
 
 
-    def fill_holes(self, labels: int | list[int] | None = None, verbose:logging=True, inplace=False):
+    def fill_holes(self, labels: int | list[int] | None = None, slice_wise_dim: int | None = None, verbose:logging=True, inplace=False):
         """Fills holes in segmentation
 
         Args:
@@ -940,6 +946,7 @@ class NII(NII_Math):
             verbose: whether to print which labels have been filled
             inplace (bool): Whether to modify the current NIfTI image object in place or create a new object with the mapped labels.
                 Default is False.
+            slice_wise_dim (int | None, optional): If the input is 3D, the specified dimension here cna be used for 2D slice-wise filling. Defaults to None.
 
         Returns:
             NII: If inplace is True, returns the current NIfTI image object with filled holes. Otherwise, returns a new NIfTI image object with filled holes.
@@ -951,7 +958,7 @@ class NII(NII_Math):
 
         seg_arr = self.get_seg_array()
         #volumes = np_volume(seg_arr, label_ref=labels)
-        filled = np_fill_holes(seg_arr, label_ref=labels)
+        filled = np_fill_holes(seg_arr, label_ref=labels, slice_wise_dim=slice_wise_dim)
         #volumes_filled = np_volume(filled, label_ref=labels)
         #changes_in_labels = [i for i in labels if i in volumes_filled and i in volumes and volumes_filled[i] != volumes[i]]
         #if len(changes_in_labels) > 0:
@@ -961,8 +968,30 @@ class NII(NII_Math):
         log.print("Fill holes called", verbose=verbose)
         return self.set_array(filled, inplace=inplace)
 
-    def fill_holes_(self, labels: int | list[int] | None = None, verbose:logging=True):
-        return self.fill_holes(labels, verbose, inplace=True)
+    def fill_holes_(self, labels: int | list[int] | None = None, slice_wise_dim: int | None = None, verbose:logging=True):
+        return self.fill_holes(labels, slice_wise_dim, verbose, inplace=True)
+
+    def calc_convex_hull(
+        self,
+        axis: DIRECTIONS = "S",
+        inplace: bool = False,
+        verbose: bool = False,
+    ):
+        """Calculates the convex hull of this segmentation nifty
+
+        Args:
+            axis (int | None, optional): If given axis, will calculate convex hull along that axis (remaining dimension must be at least 2). Defaults to None.
+        """
+        assert self.seg, "To calculate the convex hull, this must be a segmentation"
+        axis_int = self.get_axis(axis)
+        convex_hull_arr = np_calc_convex_hull(self.get_seg_array(), axis=axis_int, verbose=verbose)
+        if inplace:
+            return self.set_array_(convex_hull_arr)
+        return self.set_array(convex_hull_arr)
+
+    def calc_convex_hull_(self, axis: DIRECTIONS="S", verbose: bool = False,):
+        return self.calc_convex_hull(axis=axis, inplace=True, verbose=verbose)
+
 
     def boundary_mask(self, threshold: float,inplace = False):
         """
@@ -987,18 +1016,22 @@ class NII(NII_Math):
         """
         return self.set_array(np_calc_boundary_mask(self.get_array(),threshold),inplace=inplace,verbose=False)
 
-    def get_segmentation_connected_components(self, labels: int |list[int], connectivity: int = 3, verbose: bool=False):
+    def get_segmentation_connected_components(self, labels: int |list[int], connectivity: int = 3, transform_back_to_nii: bool = False, verbose: bool=False):
         """Calculates and returns the connected components of this segmentation NII
 
         Args:
             label (int): the label(s) of the connected components
             connectivity (int, optional): Connectivity for the connected components. Defaults to 3.
+            transform_back_to_nii (bool): If True, will map the labels to niftys, not numpy arrays. Defaults to False.
 
         Returns:
             cc: dict[label, cc_idx, arr], cc_n: dict[label, int]
         """
         arr = self.get_seg_array()
-        return np_connected_components(arr, connectivity=connectivity, label_ref=labels, verbose=verbose)
+        cc, cc_n = np_connected_components(arr, connectivity=connectivity, label_ref=labels, verbose=verbose)
+        if transform_back_to_nii:
+            cc = {i: self.set_array(k) for i,k in cc.items()}
+        return cc, cc_n
 
     def get_segmentation_connected_components_center_of_mass(self, label: int, connectivity: int = 3, sort_by_axis: int | None = None):
         """Calculates the center of mass of the different connected components of a given label in an array
@@ -1038,8 +1071,8 @@ class NII(NII_Math):
         """
         if self.orientation != mask_gt.orientation:
             mask_gt = mask_gt.reorient_same_as(self)
-        assert self.zoom == mask_gt.zoom, f"zoom mismatch, got {self.zoom} and gt zoom {mask_gt.zoom}"
-        assert self.shape == mask_gt.shape, f"shape mismatch, got {self.shape} and gt shape {mask_gt.shape}"
+
+        self.assert_affine(zoom=mask_gt.zoom, shape=mask_gt.shape)
         arr = self.get_seg_array()
         gt = mask_gt.get_seg_array()
         diff_arr = arr.copy() * 0
@@ -1057,8 +1090,23 @@ class NII(NII_Math):
 
         return self.set_array(diff_arr)
 
+    def get_overlapping_labels_to(
+        self,
+        mask_other: Self,
+    ) -> list[tuple[int, int]]:
+        """Calculates the pairs of labels that are overlapping in at least one voxel (fast)
 
-    def map_labels(self, label_map:Label_Map , verbose:logging=True, inplace=False):
+        Args:
+            mask_other (NII): The array to be compared with.
+
+        Returns:
+            list[tuple[int, int]]: List of tuples of labels that overlap in at least one voxel. First label in the tuple is Self NII, the second is of the mask_other
+        """
+        assert self.seg and mask_other.seg
+        return np_calc_overlapping_labels(self.get_seg_array(), mask_other.get_seg_array())
+
+
+    def map_labels(self, label_map:LABEL_MAP , verbose:logging=True, inplace=False):
         """
         Maps labels in the given NIfTI image according to the label_map dictionary.
         Args:
@@ -1097,7 +1145,7 @@ class NII(NII_Math):
             return self
         return NII(nii, True)
 
-    def map_labels_(self, label_map: Label_Map, verbose:logging=True):
+    def map_labels_(self, label_map: LABEL_MAP, verbose:logging=True):
         return self.map_labels(label_map,verbose=verbose,inplace=True)
     def copy(self, nib:Nifti1Image|_unpacked_nii|None = None):
         if nib is None:
@@ -1122,7 +1170,7 @@ class NII(NII_Math):
                 out.set_data_dtype(np.uint16)
             else:
                 out.set_data_dtype(np.int32)
-        log.print(f"Save {file} as {out.get_data_dtype()}",verbose=verbose,ltype=vc.log_file.Log_Type.SAVE)
+        log.print(f"Save {file} as {out.get_data_dtype()}",verbose=verbose,ltype=Log_Type.SAVE)
         nib.save(out, file) #type: ignore
     def __str__(self) -> str:
         return f"shp={self.shape}; ori={self.orientation}, zoom={tuple(np.around(self.zoom, decimals=2))}, seg={self.seg}" # type: ignore
@@ -1218,7 +1266,7 @@ class NII(NII_Math):
         b = b.resample_from_to(self,c_val=0,verbose=False)
         return b.get_array().sum()
 
-    def extract_label(self,label:int|vc.Location|Sequence[int]|Sequence[vc.Location], keep_label=False,inplace=False):
+    def extract_label(self,label:int|Location|Sequence[int]|Sequence[Location], keep_label=False,inplace=False):
         '''If this NII is a segmentation you can single out one label with [0,1].'''
         seg_arr = self.get_seg_array()
 
@@ -1230,7 +1278,7 @@ class NII(NII_Math):
                 seg_arr[seg_arr == l] = 1
             seg_arr[seg_arr != 1] = 0
         else:
-            if isinstance(label,vc.Location):
+            if isinstance(label,Location):
                 label = label.value
             assert label != 0, 'Zero label does not make sens. This is the background'
             seg_arr[seg_arr != label] = 0
@@ -1238,7 +1286,7 @@ class NII(NII_Math):
         if keep_label:
             seg_arr = seg_arr * self.get_seg_array()
         return self.set_array(seg_arr,inplace=inplace)
-    def extract_label_(self,label:int|vc.Location|Sequence[int]|Sequence[vc.Location], keep_label=False):
+    def extract_label_(self,label:int|Location|Sequence[int]|Sequence[Location], keep_label=False):
         return self.extract_label(label,keep_label,inplace=True)
     def remove_labels(self,*label:int | list[int], inplace=False, verbose:logging=True):
         '''If this NII is a segmentation you can single out one label.'''
@@ -1270,7 +1318,7 @@ class NII(NII_Math):
         '''Returns a dict stating how many pixels are present for each label'''
         return np_volume(self.get_seg_array(), include_zero=include_zero)
 
-    def center_of_masses(self) -> dict[int, Coordinate]:
+    def center_of_masses(self) -> dict[int, COORDINATE]:
         '''Returns a dict stating the center of mass for each present label (not including zero!)'''
         return np_center_of_mass(self.get_seg_array())
 
@@ -1278,8 +1326,8 @@ class NII(NII_Math):
             self,
             other: Self | "POI" | None = None,
             affine: AFFINE | None = None,
-            zoom: Zooms | None = None,
-            orientation: Ax_Codes | None = None,
+            zoom: ZOOMS | None = None,
+            orientation: AX_CODES | None = None,
             rotation: ROTATION | None = None,
             origin: ORIGIN | None = None,
             shape: SHAPE | None = None,
@@ -1311,7 +1359,7 @@ class NII(NII_Math):
         # Make Checks
         if other is not None:
             other_data = other._extract_affine()
-            other_match = self.assert_affine(other=None, **other_data, raise_error=raise_error)
+            other_match = self.assert_affine(other=None, **other_data, raise_error=raise_error, error_tolerance=error_tolerance)
             if not other_match:
                 found_errors.append(f"object mismatch {self!s}, {other!s}")
         if affine is not None:
@@ -1340,7 +1388,7 @@ class NII(NII_Math):
 
         # Print errors
         for err in found_errors:
-            log.print(err, verbose=verbose)
+            log.print(err, Log_Type.FAIL, verbose=verbose)
 
         # Final conclusion and possible raising of AssertionError
         has_errors = len(found_errors) > 0
@@ -1393,7 +1441,7 @@ def to_nii_interpolateable(i_img:Interpolateable_Image_Reference) -> NII:
 
 def _resample_from_to(
     from_img:NII,
-    to_img:NII|tuple[SHAPE,AFFINE,Zooms],
+    to_img:NII|tuple[SHAPE,AFFINE,ZOOMS],
     order=3,
     mode="constant",
     align_corners:bool|Sentinel=Sentinel()  # noqa: B008

--- a/TPTBox/core/nii_wrapper.py
+++ b/TPTBox/core/nii_wrapper.py
@@ -1350,22 +1350,21 @@ class NII(NII_Math):
         """Checks if the different metadata is equal to some comparison entries
 
         Args:
-            other (Self | &quot;POI&quot; | None, optional): _description_. Defaults to None.
-            affine (AFFINE | None, optional): _description_. Defaults to None.
-            zms (Zooms | None, optional): _description_. Defaults to None.
-            orientation (Ax_Codes | None, optional): _description_. Defaults to None.
-            origin (ORIGIN | None, optional): _description_. Defaults to None.
-            shape (SHAPE | None, optional): _description_. Defaults to None.
-            error_tolerance (float, optional): _description_. Defaults to 1e-4.
-            raise_error (bool, optional): _description_. Defaults to True.
-            verbose (logging, optional): _description_. Defaults to False.
+            other (Self | POI | None, optional): If set, will assert each entry of that object instead. Defaults to None.
+            affine (AFFINE | None, optional): Affine matrix to compare against. If none, will not assert affine. Defaults to None.
+            zms (Zooms | None, optional): Zoom to compare against. If none, will not assert zoom. Defaults to None.
+            orientation (Ax_Codes | None, optional): Orientation to compare against. If none, will not assert orientation. Defaults to None.
+            origin (ORIGIN | None, optional): Origin to compare against. If none, will not assert origin. Defaults to None.
+            shape (SHAPE | None, optional): Shape to compare against. If none, will not assert shape. Defaults to None.
+            error_tolerance (float, optional): Accepted error tolerance in all assertions except shape. Defaults to 1e-4.
+            raise_error (bool, optional): If true, will raise AssertionError if anything is found. Defaults to True.
+            verbose (logging, optional): If true, will print out each assertion mismatch. Defaults to False.
 
         Raises:
-            NotImplementedError: _description_
-            AssertionError: _description_
+            AssertionError: If any of the assertions failed and raise_error is True
 
         Returns:
-            _type_: _description_
+            bool: True if there are no assertion errors
         """
         found_errors: list[str] = []
 

--- a/TPTBox/core/np_utils.py
+++ b/TPTBox/core/np_utils.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import Any, TypeVar
 
 import numpy as np
+import scipy
 from cc3d import connected_components, contacts, region_graph, voxel_connectivity_graph
 from cc3d import statistics as _cc3dstats
 from fill_voids import fill
@@ -11,7 +12,7 @@ from numpy.typing import NDArray
 from scipy.ndimage import binary_erosion, center_of_mass, generate_binary_structure
 from skimage.measure import euler_number, label
 
-from TPTBox.core.vert_constants import Coordinate, Label_Map, Label_Reference, log
+from TPTBox.core.vert_constants import COORDINATE, LABEL_MAP, LABEL_REFERENCE, log
 from TPTBox.logger import Log_Type
 
 UINT = TypeVar("UINT", bound=np.unsignedinteger[Any])
@@ -114,7 +115,7 @@ def np_unique_withoutzero(arr: UINTARRAY) -> list[int]:
     return [i for i in np.unique(arr) if i != 0]
 
 
-def np_center_of_mass(arr: UINTARRAY) -> dict[int, Coordinate]:
+def np_center_of_mass(arr: UINTARRAY) -> dict[int, COORDINATE]:
     """Calculates center of mass, mapping label in array to a coordinate (float) (exluding zero)
 
     Args:
@@ -238,7 +239,7 @@ def np_dice(seg: np.ndarray, gt: np.ndarray, binary_compare: bool = False, label
 
 
 def np_dilate_msk(
-    arr: np.ndarray, label_ref: Label_Reference = None, mm: int = 5, connectivity: int = 3, mask: np.ndarray | None = None
+    arr: np.ndarray, label_ref: LABEL_REFERENCE = None, mm: int = 5, connectivity: int = 3, mask: np.ndarray | None = None
 ) -> np.ndarray:
     """
     Dilates the given array by the specified number of voxels (not including the zero).
@@ -277,7 +278,7 @@ def np_dilate_msk(
     return out
 
 
-def np_erode_msk(arr: np.ndarray, label_ref: Label_Reference = None, mm: int = 5, connectivity: int = 3) -> np.ndarray:
+def np_erode_msk(arr: np.ndarray, label_ref: LABEL_REFERENCE = None, mm: int = 5, connectivity: int = 3) -> np.ndarray:
     """
     Erodes the given array by the specified number of voxels.
 
@@ -308,7 +309,7 @@ def np_erode_msk(arr: np.ndarray, label_ref: Label_Reference = None, mm: int = 5
     return out
 
 
-def np_map_labels(arr: UINTARRAY, label_map: Label_Map) -> np.ndarray:
+def np_map_labels(arr: UINTARRAY, label_map: LABEL_MAP) -> np.ndarray:
     """Maps labels in the given array according to the label_map dictionary.
     Args:
         label_map (dict): A dictionary that maps the original label values (str or int) to the new label values (int).
@@ -420,7 +421,7 @@ def np_center_of_bbox_binary(img: np.ndarray, px_dist: int | Sequence[int] | np.
     return ctd_bbox
 
 
-def np_approx_center_of_mass(seg: np.ndarray, label_ref: Label_Reference = None) -> dict[int, Coordinate]:
+def np_approx_center_of_mass(seg: np.ndarray, label_ref: LABEL_REFERENCE = None) -> dict[int, COORDINATE]:
     import warnings
 
     warnings.warn("np_approx_center_of_mass deprecated use np_center_of_mass instead", stacklevel=3)  # TODO remove in version 1.0
@@ -472,7 +473,7 @@ def np_find_index_of_k_max_values(arr: np.ndarray, k: int = 2) -> list[int]:
 def np_connected_components(
     arr: UINTARRAY,
     connectivity: int = 3,
-    label_ref: Label_Reference = None,
+    label_ref: LABEL_REFERENCE = None,
     verbose: bool = False,
 ) -> tuple[dict[int, UINTARRAY], dict[int, int]]:
     """Calculates the connected components of a given array (works with zeros as well!)
@@ -513,7 +514,7 @@ def np_connected_components(
 def np_get_largest_k_connected_components(
     arr: UINTARRAY,
     k: int | None = None,
-    label_ref: Label_Reference = None,
+    label_ref: LABEL_REFERENCE = None,
     connectivity: int = 3,
     return_original_labels: bool = True,
 ) -> UINTARRAY:
@@ -561,7 +562,7 @@ def np_get_largest_k_connected_components(
 
 def np_get_connected_components_center_of_mass(
     arr: UINTARRAY, label: int, connectivity: int = 3, sort_by_axis: int | None = None
-) -> list[Coordinate]:
+) -> list[COORDINATE]:
     """Calculates the center of mass of the different connected components of a given label in an array
 
     Args:
@@ -644,7 +645,7 @@ def np_translate_arr(arr: np.ndarray, translation_vector: tuple[int, int] | tupl
     return arr_translated
 
 
-def np_fill_holes(arr: np.ndarray, label_ref: Label_Reference = None, slice_wise_dim: int | None = None) -> np.ndarray:
+def np_fill_holes(arr: np.ndarray, label_ref: LABEL_REFERENCE = None, slice_wise_dim: int | None = None) -> np.ndarray:
     """Fills holes in segmentations
 
     Args:
@@ -671,6 +672,67 @@ def np_fill_holes(arr: np.ndarray, label_ref: Label_Reference = None, slice_wise
         filled[filled != 0] = l
         arr[arr == 0] = filled[arr == 0]
     return arr
+
+
+def np_calc_convex_hull(
+    arr: INTARRAY,
+    axis: int | None = None,
+    verbose: bool = False,
+):
+    """Calculates the convex hull of a given array, returning the array filled with its convex hull
+
+    Args:
+        arr (INTARRAY): Input array
+        axis (int | None, optional): If given axis, will calculate convex hull along that axis (remaining dimension must be at least 2). Defaults to None.
+    """
+    n_dims = arr.ndim
+    if axis is None:
+        assert 2 <= n_dims <= 3, f"If axis is none, array must be 2- or 3-dimensional, but got {n_dims} with shape {arr.shape}"
+        return _convex_hull(arr, verbose=verbose)[0]
+    else:
+        assert 3 <= n_dims <= 4, f"If axis is given, the array must be 3- or 4-dimensional, but got {n_dims} with shape {arr.shape}"
+        assert 0 <= axis <= n_dims, f"Specified axis must be in range of dimension, but got axis={axis} and n_dims={n_dims}"
+        h = arr * 0
+        for i in range(arr.shape[axis]):
+            slices = _select_axis_dynamically(axis=axis, index=i, n_dims=n_dims)
+            if np.count_nonzero(arr[slices]) == 0:
+                continue
+            try:
+                convex_hull_slice = _convex_hull(arr[slices], verbose=verbose)[0].astype(arr.dtype)
+                h[slices] += convex_hull_slice
+            except Exception:
+                pass
+        return h
+
+
+def _select_axis_dynamically(axis: int, index: int, n_dims: int = 3):
+    slices = tuple([slice(None) if i != axis else index for i in range(n_dims)])
+    return slices
+
+
+def _convex_hull(
+    arr: INTARRAY,
+    verbose: bool = False,
+):
+    """Calculates the convex hull of a given array (all labels are taken)
+
+    Args:
+        arr (INTARRAY): integer array
+
+    Returns:
+        _type_: out_img, hull
+    """
+    points = np.transpose(np.where(arr))
+    if len(points) <= 3:
+        print("To few points") if verbose else None
+        return np.zeros_like(arr, dtype=arr.dtype)
+    hull = scipy.spatial.ConvexHull(points)
+    deln = scipy.spatial.Delaunay(points[hull.vertices])
+    idx = np.stack(np.indices(arr.shape), axis=-1)
+    out_idx = np.nonzero(deln.find_simplex(idx) + 1)
+    out_img = np.zeros(arr.shape, dtype=arr.dtype)
+    out_img[out_idx] = 1
+    return out_img, hull
 
 
 def np_calc_boundary_mask(
@@ -784,7 +846,33 @@ def np_betti_numbers(img: np.ndarray, verbose=False) -> tuple[int, int, int]:
     return b0, b1, b2
 
 
-def _to_labels(arr: np.ndarray, labels: Label_Reference = None) -> Sequence[int]:
+def np_calc_overlapping_labels(
+    reference_arr: np.ndarray,
+    prediction_arr: np.ndarray,
+) -> list[tuple[int, int]]:
+    """Calculates the pairs of labels that are overlapping in at least one voxel (fast)
+
+    Args:
+        prediction_arr (np.ndarray): Numpy array containing the prediction labels.
+        reference_arr (np.ndarray): Numpy array containing the reference labels.
+        ref_labels (list[int]): List of unique reference labels.
+
+    Returns:
+        list[tuple[int, int]]: List of tuples of labels that overlap in at least one voxel
+    """
+    ref_labels = np_unique_withoutzero(reference_arr)
+    overlap_arr = prediction_arr.astype(np.uint32)
+    max_ref = max(ref_labels) + 1
+    overlap_arr = (overlap_arr * max_ref) + reference_arr
+    overlap_arr[reference_arr == 0] = 0
+    # overlapping_indices = [(i % (max_ref), i // (max_ref)) for i in np.unique(overlap_arr) if i > max_ref]
+    # instance_pairs = [(reference_arr, prediction_arr, i, j) for i, j in overlapping_indices]
+
+    # (ref, pred)
+    return [(int(i % (max_ref)), int(i // (max_ref))) for i in np.unique(overlap_arr) if i > max_ref]
+
+
+def _to_labels(arr: np.ndarray, labels: LABEL_REFERENCE = None) -> Sequence[int]:
     if labels is None:
         labels = list(np_unique(arr))
     if not isinstance(labels, Sequence):

--- a/TPTBox/core/poi.py
+++ b/TPTBox/core/poi.py
@@ -13,18 +13,22 @@ import numpy as np
 from scipy.ndimage import center_of_mass
 from typing_extensions import Self
 
+from ..logger import Log_Type  # noqa: TID252
 from . import bids_files
 from .nii_wrapper import NII, Image_Reference, to_nii, to_nii_optional
 from .poi_abstract import ROUNDING_LVL, Abstract_POI, POI_Descriptor, Sentinel
 from .vert_constants import (
+    AFFINE,
+    AX_CODES,
+    COORDINATE,
     LABEL_MAX,
-    Ax_Codes,
-    Coordinate,
+    ORIGIN,
+    POI_DICT,
+    ROTATION,
+    SHAPE,
+    TRIPLE,
+    ZOOMS,
     Location,
-    POI_Dict,
-    Rotation,
-    Triple,
-    Zooms,
     conversion_poi,
     conversion_poi2text,
     log,
@@ -117,13 +121,13 @@ class POI(Abstract_POI):
         POI(centroids={4: {0: (5.0, 10.0, 15.0), 1: (8.0, 12.0, 18.0)}, 3: {0: (5.0, 15.0, 25.0)}}, orientation=('R', 'A', 'S'), zoom=(2.0, 2.0, 2.0), info={}, origin=None)
     """
 
-    orientation: Ax_Codes = ("R", "A", "S")
-    zoom: None | Zooms = field(init=True, default=None)  # type: ignore
-    shape: Triple | None = field(default=None, repr=True, compare=False)
-    rotation: Rotation | None = field(default=None, repr=False, compare=False)
-    origin: Coordinate | None = None
+    orientation: AX_CODES = ("R", "A", "S")
+    zoom: None | ZOOMS = field(init=True, default=None)  # type: ignore
+    shape: TRIPLE | None = field(default=None, repr=True, compare=False)
+    rotation: ROTATION | None = field(default=None, repr=False, compare=False)
+    origin: COORDINATE | None = None
     # internal
-    _zoom: None | Zooms = field(init=False, default=None, repr=False, compare=False)
+    _zoom: None | ZOOMS = field(init=False, default=None, repr=False, compare=False)
     _vert_orientation_pir = {}  # Elusive; will not be saved; will not be copied. For Buffering results  # noqa: RUF012
 
     @property
@@ -166,12 +170,12 @@ class POI(Abstract_POI):
 
     def copy(
         self,
-        centroids: POI_Dict | POI_Descriptor | None = None,
-        orientation: Ax_Codes | None = None,
-        zoom: Zooms | None | Sentinel = Sentinel(),  # noqa: B008
+        centroids: POI_DICT | POI_Descriptor | None = None,
+        orientation: AX_CODES | None = None,
+        zoom: ZOOMS | None | Sentinel = Sentinel(),  # noqa: B008
         shape: tuple[float, float, float] | tuple[float, ...] | None | Sentinel = Sentinel(),  # noqa: B008
-        rotation: Rotation | None | Sentinel = Sentinel(),  # noqa: B008
-        origin: Coordinate | None | Sentinel = Sentinel(),  # noqa: B008
+        rotation: ROTATION | None | Sentinel = Sentinel(),  # noqa: B008
+        origin: COORDINATE | None | Sentinel = Sentinel(),  # noqa: B008
     ) -> Self:
         """Create a copy of the POI object with optional attribute overrides.
 
@@ -209,7 +213,7 @@ class POI(Abstract_POI):
             format=self.format,
         )
 
-    def local_to_global(self, x: Coordinate) -> Coordinate:
+    def local_to_global(self, x: COORDINATE) -> COORDINATE:
         """Converts local coordinates to global coordinates using zoom, rotation, and origin.
 
         Args:
@@ -240,7 +244,7 @@ class POI(Abstract_POI):
         # return tuple(a.tolist())
         return tuple(round(float(v), ROUNDING_LVL) for v in a)
 
-    def global_to_local(self, x: Coordinate) -> Coordinate:
+    def global_to_local(self, x: COORDINATE) -> COORDINATE:
         """Converts global coordinates to local coordinates using zoom, rotation, and origin.
 
         Args:
@@ -342,7 +346,7 @@ class POI(Abstract_POI):
                     else:
                         return end + in_shape[i]
 
-                shape: Triple | None = tuple(int(map_v(o_shift[i], i) - o_shift[i].start) for i in range(3))  # type: ignore
+                shape: TRIPLE | None = tuple(int(map_v(o_shift[i], i) - o_shift[i].start) for i in range(3))  # type: ignore
             if self.origin is not None:
                 origin = self.local_to_global(tuple(float(y.start) for y in o_shift))  # type: ignore
                 # origin = tuple(float(x + y.start) for x, y in zip(self.origin, o_shift))
@@ -392,7 +396,7 @@ class POI(Abstract_POI):
             return self
         return self.apply_crop(translation_vector, inplace=inplace, **kwargs)
 
-    def reorient(self, axcodes_to: Ax_Codes = ("P", "I", "R"), decimals=ROUNDING_LVL, verbose: logging = False, inplace=False, _shape=None):
+    def reorient(self, axcodes_to: AX_CODES = ("P", "I", "R"), decimals=ROUNDING_LVL, verbose: logging = False, inplace=False, _shape=None):
         """Reorients the centroids of an image from the current orientation to the specified orientation.
 
         This method updates the position of the centroids, zoom level, and shape of the image accordingly.
@@ -463,7 +467,7 @@ class POI(Abstract_POI):
         if self.zoom is not None:
             zoom_i = np.array(self.zoom)
             zoom_i[perm] = zoom_i.copy()
-            zoom: Zooms | None = tuple(zoom_i)
+            zoom: ZOOMS | None = tuple(zoom_i)
         else:
             zoom = None
         perm2 = trans[:, 0]
@@ -496,20 +500,20 @@ class POI(Abstract_POI):
             return self
         return self.copy(orientation=axcodes_to, centroids=points, zoom=zoom, shape=shape, origin=origin, rotation=rotation)
 
-    def reorient_(self, axcodes_to: Ax_Codes = ("P", "I", "R"), decimals=3, verbose: logging = False, _shape=None):
+    def reorient_(self, axcodes_to: AX_CODES = ("P", "I", "R"), decimals=3, verbose: logging = False, _shape=None):
         return self.reorient(axcodes_to, decimals=decimals, verbose=verbose, inplace=True, _shape=_shape)
 
     def reorient_centroids_to(self, img: Image_Reference, decimals=ROUNDING_LVL, verbose: logging = False, inplace=False) -> Self:
         # reorient centroids to image orientation
         if not isinstance(img, NII):
             img = to_nii(img)
-        axcodes_to: Ax_Codes = nio.aff2axcodes(img.affine)  # type: ignore
+        axcodes_to: AX_CODES = nio.aff2axcodes(img.affine)  # type: ignore
         return self.reorient(axcodes_to, decimals=decimals, verbose=verbose, inplace=inplace, _shape=img.shape)
 
     def reorient_centroids_to_(self, img: Image_Reference, decimals=ROUNDING_LVL, verbose: logging = False) -> Self:
         return self.reorient_centroids_to(img, decimals=decimals, verbose=verbose, inplace=True)
 
-    def rescale(self, voxel_spacing: Zooms = (1, 1, 1), decimals=ROUNDING_LVL, verbose: logging = True, inplace=False) -> Self:
+    def rescale(self, voxel_spacing: ZOOMS = (1, 1, 1), decimals=ROUNDING_LVL, verbose: logging = True, inplace=False) -> Self:
         """Rescale the centroid coordinates to a new voxel spacing in the current x-y-z-orientation.
 
         Args:
@@ -557,7 +561,7 @@ class POI(Abstract_POI):
             return self
         return self.copy(centroids=points, zoom=voxel_spacing, shape=shp)
 
-    def rescale_(self, voxel_spacing: Zooms = (1, 1, 1), decimals=3, verbose: logging = False) -> Self:
+    def rescale_(self, voxel_spacing: ZOOMS = (1, 1, 1), decimals=3, verbose: logging = False) -> Self:
         return self.rescale(voxel_spacing=voxel_spacing, decimals=decimals, verbose=verbose, inplace=True)
 
     def to_global(self):
@@ -767,39 +771,111 @@ class POI(Abstract_POI):
         """
         return load_poi(poi)
 
-    def assert_affine(self, nii: NII | Self):
-        return
-        assert self.zoom is not None
-        assert nii.zoom is not None
-        assert np.isclose(self.zoom, nii.zoom, rtol=0.001).all()
-        assert self.orientation == nii.orientation, (self.orientation, nii.orientation)
-        s = self.shape_int
-        if isinstance(nii, NII):
-            assert s is not None
-            s = tuple(round(x, 0) for x in s)
-        atol = 10  # 0.01  # 1e-5
-        assert s == nii.shape, (s, nii.shape, self, str(nii))
-        assert self.rotation is not None
-        assert nii.rotation is not None
-        assert self.rotation is not None
-        assert nii.rotation is not None
-        assert np.isclose(self.rotation, nii.rotation, atol=atol).all()
-        assert self.origin is not None
-        assert nii.origin is not None
-        assert nii.origin is not None
-        assert self.origin is not None
+    def assert_affine(
+        self,
+        other: Self | NII | None = None,
+        ignore_missing_values: bool = False,
+        affine: AFFINE | None = None,
+        zoom: ZOOMS | None = None,
+        orientation: AX_CODES | None = None,
+        rotation: ROTATION | None = None,
+        origin: ORIGIN | None = None,
+        shape: SHAPE | None = None,
+        shape_tolerance: float = 0.0,
+        error_tolerance: float = 1e-4,
+        raise_error: bool = True,
+        verbose: logging = False,
+    ):
+        """Checks if the different metadata is equal to some comparison entries
 
-        aff_equ = np.isclose(self.affine, nii.affine, atol=atol).all()
-        assert aff_equ, f"{np.round(self.affine,2)}\n {np.round(nii.affine,2)}"
-        assert np.isclose(self.origin, nii.origin, atol=atol).all(), (self.origin, nii.origin)
+        Args:
+            other (Self | &quot;POI&quot; | None, optional): _description_. Defaults to None.
+            affine (AFFINE | None, optional): _description_. Defaults to None.
+            zms (Zooms | None, optional): _description_. Defaults to None.
+            orientation (Ax_Codes | None, optional): _description_. Defaults to None.
+            origin (ORIGIN | None, optional): _description_. Defaults to None.
+            shape (SHAPE | None, optional): _description_. Defaults to None.
+            error_tolerance (float, optional): _description_. Defaults to 1e-4.
+            raise_error (bool, optional): _description_. Defaults to True.
+            verbose (logging, optional): _description_. Defaults to False.
+
+        Raises:
+            NotImplementedError: _description_
+            AssertionError: _description_
+
+        Returns:
+            _type_: _description_
+        """
+        found_errors: list[str] = []
+
+        # Make Checks
+        if other is not None:
+            other_data = other._extract_affine()
+            other_match = self.assert_affine(
+                other=None, **other_data, raise_error=raise_error, shape_tolerance=shape_tolerance, error_tolerance=error_tolerance
+            )
+            if not other_match:
+                found_errors.append(f"object mismatch {self!s}, {other!s}")
+        if affine is not None and (not ignore_missing_values or self.affine is not None):
+            if self.affine is None:
+                found_errors.append(f"affine mismatch {self.affine}, {affine}")
+            else:
+                affine_diff = self.affine - affine
+                affine_match = np.all([abs(a) <= error_tolerance for a in affine_diff.flatten()])
+                found_errors.append(f"affine mismatch {self.affine}, {affine}") if not affine_match else None
+        if rotation is not None and (not ignore_missing_values or self.rotation is not None):
+            if self.rotation is None:
+                found_errors.append(f"rotation mismatch {self.rotation}, {rotation}")
+            else:
+                rotation_diff = self.rotation - rotation
+                rotation_match = np.all([abs(a) <= error_tolerance for a in rotation_diff.flatten()])
+                found_errors.append(f"rotation mismatch {self.rotation}, {rotation}") if not rotation_match else None
+        if zoom is not None and (not ignore_missing_values or self.zoom is not None):
+            if self.zoom is None:
+                found_errors.append(f"zoom mismatch {self.zoom}, {zoom}")
+            else:
+                zms_diff = (self.zoom[i] - zoom[i] for i in range(3))
+                zms_match = np.all([abs(a) <= error_tolerance for a in zms_diff])
+                found_errors.append(f"zoom mismatch {self.zoom}, {zoom}") if not zms_match else None
+        if orientation is not None and (not ignore_missing_values or self.affine is not None):
+            if self.orientation is None:
+                found_errors.append(f"orientation mismatch {self.orientation}, {orientation}")
+            else:
+                orientation_match = np.all([i == orientation[idx] for idx, i in enumerate(self.orientation)])
+                found_errors.append(f"orientation mismatch {self.orientation}, {orientation}") if not orientation_match else None
+        if origin is not None and (not ignore_missing_values or self.origin is not None):
+            if self.origin is None:
+                found_errors.append(f"origin mismatch {self.origin}, {origin}")
+            else:
+                origin_diff = (self.origin[i] - origin[i] for i in range(3))
+                origin_match = np.all([abs(a) <= error_tolerance for a in origin_diff])
+                found_errors.append(f"origin mismatch {self.origin}, {origin}") if not origin_match else None
+        if shape is not None and (not ignore_missing_values or self.shape is not None):
+            if self.shape is None:
+                found_errors.append(f"shape mismatch {self.shape}, {shape}")
+            else:
+                shape_diff = (float(self.shape[i]) - float(shape[i]) for i in range(3))
+                shape_match = np.all([abs(a) <= shape_tolerance for a in shape_diff])
+                found_errors.append(f"shape mismatch {self.shape}, {shape}") if not shape_match else None
+
+        # Print errors
+        for err in found_errors:
+            log.print(err, Log_Type.FAIL, verbose=verbose)
+
+        # Final conclusion and possible raising of AssertionError
+        has_errors = len(found_errors) > 0
+        if raise_error and has_errors:
+            raise AssertionError(f"assert_affine failed with {found_errors}")
+
+        return not has_errors
 
 
 class VertebraCentroids(POI):
     def __init__(
         self,
         _centroids,
-        _orientation: Ax_Codes,
-        _shape: Triple | None,
+        _orientation: AX_CODES,
+        _shape: TRIPLE | None,
         zoom=None,
         **qargs,
     ):
@@ -954,8 +1030,8 @@ def load_poi(ctd_path: POI_Reference, verbose=True) -> POI:  # noqa: ARG001
         return _load_format_POI_old(dict_list)  # This file if used in the old POI-pipeline and is deprecated
 
     assert "direction" in dict_list[0], f'File format error: first index must be a "Direction" but got {dict_list[0]}'
-    axcode: Ax_Codes = tuple(dict_list[0]["direction"])  # type: ignore
-    zoom: Zooms = dict_list[0].get("zoom", None)  # type: ignore
+    axcode: AX_CODES = tuple(dict_list[0]["direction"])  # type: ignore
+    zoom: ZOOMS = dict_list[0].get("zoom", None)  # type: ignore
     shape = dict_list[0].get("shape", None)  # type: ignore
     shape = tuple(shape) if shape is not None else None
     format_ = dict_list[0].get("format", None)
@@ -1553,14 +1629,14 @@ def calc_centroids(
     assert vert_id == -1 or subreg_id == -1, "first or second dimension must be fixed."
     msk_nii = to_nii(msk, seg=True)
     msk_data = msk_nii.get_seg_array()
-    axc: Ax_Codes = nio.aff2axcodes(msk_nii.affine)  # type: ignore
+    axc: AX_CODES = nio.aff2axcodes(msk_nii.affine)  # type: ignore
     if extend_to is None:
         ctd_list = POI_Descriptor()
     else:
         if not inplace:
             extend_to = extend_to.copy()
         ctd_list = extend_to.centroids
-        extend_to.assert_affine(msk_nii)
+        extend_to.assert_affine(msk_nii, shape_tolerance=0.5)
         # assert extend_to.orientation == axc, (extend_to.orientation, axc)
     for i in msk_nii.unique():
         msk_temp = np.zeros(msk_data.shape, dtype=bool)

--- a/TPTBox/core/poi.py
+++ b/TPTBox/core/poi.py
@@ -789,22 +789,22 @@ class POI(Abstract_POI):
         """Checks if the different metadata is equal to some comparison entries
 
         Args:
-            other (Self | &quot;POI&quot; | None, optional): _description_. Defaults to None.
-            affine (AFFINE | None, optional): _description_. Defaults to None.
-            zms (Zooms | None, optional): _description_. Defaults to None.
-            orientation (Ax_Codes | None, optional): _description_. Defaults to None.
-            origin (ORIGIN | None, optional): _description_. Defaults to None.
-            shape (SHAPE | None, optional): _description_. Defaults to None.
-            error_tolerance (float, optional): _description_. Defaults to 1e-4.
-            raise_error (bool, optional): _description_. Defaults to True.
-            verbose (logging, optional): _description_. Defaults to False.
+            other (Self | POI | None, optional): If set, will assert each entry of that object instead. Defaults to None.
+            affine (AFFINE | None, optional): Affine matrix to compare against. If none, will not assert affine. Defaults to None.
+            zms (Zooms | None, optional): Zoom to compare against. If none, will not assert zoom. Defaults to None.
+            orientation (Ax_Codes | None, optional): Orientation to compare against. If none, will not assert orientation. Defaults to None.
+            origin (ORIGIN | None, optional): Origin to compare against. If none, will not assert origin. Defaults to None.
+            shape (SHAPE | None, optional): Shape to compare against. If none, will not assert shape. Defaults to None.
+            shape_tolerance (float, optional): error tolerance in shape as float, as POIs can have float shapes. Defaults to 0.0.
+            error_tolerance (float, optional): Accepted error tolerance in all assertions except shape. Defaults to 1e-4.
+            raise_error (bool, optional): If true, will raise AssertionError if anything is found. Defaults to True.
+            verbose (logging, optional): If true, will print out each assertion mismatch. Defaults to False.
 
         Raises:
-            NotImplementedError: _description_
-            AssertionError: _description_
+            AssertionError: If any of the assertions failed and raise_error is True
 
         Returns:
-            _type_: _description_
+            bool: True if there are no assertion errors
         """
         found_errors: list[str] = []
 

--- a/TPTBox/core/poi_abstract.py
+++ b/TPTBox/core/poi_abstract.py
@@ -12,7 +12,7 @@ from typing_extensions import Self
 from TPTBox.core.nii_wrapper import NII
 
 from . import vert_constants
-from .vert_constants import Coordinate, Location, POI_Dict, Sentinel, log, log_file, logging
+from .vert_constants import COORDINATE, POI_DICT, Location, Sentinel, log, log_file, logging
 
 ROUNDING_LVL = 7
 POI_ID = tuple[int, int] | slice | tuple[Location, Location] | tuple[Location, int] | tuple[int, Location]
@@ -72,7 +72,7 @@ class POI_Descriptor(AbstractSet, MutableMapping):
     def __init__(
         self,
         *,
-        default: POI_Dict | None = None,
+        default: POI_DICT | None = None,
         definition: Abstract_POI_Definition | None = None,
     ):
         if definition is None:
@@ -131,7 +131,7 @@ class POI_Descriptor(AbstractSet, MutableMapping):
         self.sort()
         return self.pois.copy().items()
 
-    def _apply_all(self, fun: Callable[[float, float, float], Coordinate], inplace=False):
+    def _apply_all(self, fun: Callable[[float, float, float], COORDINATE], inplace=False):
         out = self if inplace else POI_Descriptor()
         for region, subregion, cord in self.items():
             out[region:subregion] = fun(*cord)
@@ -150,11 +150,11 @@ class POI_Descriptor(AbstractSet, MutableMapping):
     def keys_subregion(self):
         return {x2 for x1, x2, y in self.items()}
 
-    def __getitem__(self, key: POI_ID) -> Coordinate:
+    def __getitem__(self, key: POI_ID) -> COORDINATE:
         region, subregion = unpack_poi_id(key, self.definition)
         return self.pois[region][subregion]
 
-    def __setitem__(self, key: POI_ID, value: Coordinate):
+    def __setitem__(self, key: POI_ID, value: COORDINATE):
         self._len = None
         region, subregion = unpack_poi_id(key, self.definition)
         if region not in self.pois:
@@ -287,19 +287,21 @@ class Abstract_POI:
     def _get_centroids(self) -> POI_Descriptor:
         return self.centroids  # type: ignore
 
-    def apply_all(self, fun: Callable[[float, float, float], Coordinate], inplace=False):
+    def apply_all(self, fun: Callable[[float, float, float], COORDINATE], inplace=False):
         ctd = self._get_centroids()._apply_all(fun, inplace)
         if inplace:
             return self
         return self.copy(ctd)
 
     @property
-    def is_global(self) -> bool: ...
+    def is_global(self) -> bool:
+        ...
 
     def clone(self, **qargs):
         return self.copy(**qargs)
 
-    def copy(self, centroids: POI_Descriptor | None = None, **qargs) -> Self: ...
+    def copy(self, centroids: POI_Descriptor | None = None, **qargs) -> Self:
+        ...
 
     def map_labels(
         self,
@@ -472,7 +474,7 @@ class Abstract_POI:
     def __contains__(self, key: POI_ID) -> bool:
         return key in self.centroids
 
-    def __getitem__(self, key: POI_ID) -> Coordinate:
+    def __getitem__(self, key: POI_ID) -> COORDINATE:
         return tuple(self.centroids[key])
 
     def __setitem__(self, key: POI_ID, value: tuple[float, float, float] | Sequence[float]):
@@ -505,7 +507,7 @@ class Abstract_POI:
     def keys_subregion(self):
         return list(self.centroids.keys_subregion())
 
-    def values(self) -> list[Coordinate]:
+    def values(self) -> list[COORDINATE]:
         return self.centroids.values()
 
     def remove_centroid_(self, *label: tuple[int, int]):

--- a/TPTBox/core/sitk_utils.py
+++ b/TPTBox/core/sitk_utils.py
@@ -296,7 +296,7 @@ def sitk_to_nii(image: sitk.Image, seg: bool) -> "NII":
 
 def transform_centroid(ctd: "POI", transform: sitk.Transform, img_fixed: sitk.Image, img_moving: sitk.Image, reg_type):
     import TPTBox
-    from TPTBox.core.poi import POI, POI_Descriptor, POI_Dict
+    from TPTBox.core.poi import POI, POI_DICT, POI_Descriptor
 
     out = TPTBox.core.poi.POI_Descriptor()
 

--- a/TPTBox/core/vert_constants.py
+++ b/TPTBox/core/vert_constants.py
@@ -6,28 +6,34 @@ import numpy as np
 
 from TPTBox.logger import log_file
 
+#####################
 log = log_file.Reflection_Logger()
 logging = bool | log_file.Logger_Interface
 # R: Right, L: Left; S: Superior (up), I: Inferior (down); A: Anterior (front), P: Posterior (back)
-Directions = Literal["R", "L", "S", "I", "A", "P"]
-Ax_Codes = tuple[Directions, Directions, Directions]
+DIRECTIONS = Literal["R", "L", "S", "I", "A", "P"]
+AX_CODES = tuple[DIRECTIONS, DIRECTIONS, DIRECTIONS]
+ROTATION = np.ndarray
+ZOOMS = tuple[float, float, float] | Sequence[float]
+#####################
 LABEL_MAX = 256
-Zooms = tuple[float, float, float] | Sequence[float]
 
-Centroid_Dict = dict[int, tuple[float, float, float]]
-Triple = tuple[float, float, float] | Sequence[float]
-Coordinate = Triple
-POI_Dict = dict[int, dict[int, Coordinate]]
+CENTROID_DICT = dict[int, tuple[float, float, float]]
+TRIPLE = tuple[float, float, float] | Sequence[float]
+COORDINATE = TRIPLE
+POI_DICT = dict[int, dict[int, COORDINATE]]
 
-
-Rotation = np.ndarray
-Label_Map = dict[int | str, int | str] | dict[str, str] | dict[int, int]
-
-Label_Reference = int | Sequence[int] | None
+AFFINE = np.ndarray
+SHAPE = TRIPLE | tuple[int, int, int]
+ORIGIN = TRIPLE
 
 
-plane_dict: dict[Directions, str] = {"S": "ax", "I": "ax", "L": "sag", "R": "sag", "A": "cor", "P": "cor"}
-same_direction: dict[Directions, Directions] = {"S": "I", "I": "S", "L": "R", "R": "L", "A": "P", "P": "A"}
+LABEL_MAP = dict[int | str, int | str] | dict[str, str] | dict[int, int]
+
+LABEL_REFERENCE = int | Sequence[int] | None
+
+
+_plane_dict: dict[DIRECTIONS, str] = {"S": "ax", "I": "ax", "L": "sag", "R": "sag", "A": "cor", "P": "cor"}
+_same_direction: dict[DIRECTIONS, DIRECTIONS] = {"S": "I", "I": "S", "L": "R", "R": "L", "A": "P", "P": "A"}
 
 
 def never_called(args: NoReturn) -> NoReturn:  # noqa: ARG001

--- a/TPTBox/core/vertebra_pois_non_centroids.py
+++ b/TPTBox/core/vertebra_pois_non_centroids.py
@@ -8,7 +8,7 @@ from scipy.linalg import norm
 from scipy.spatial.distance import cdist
 
 from TPTBox import NII, POI, Log_Type, Logger_Interface, Print_Logger, calc_poi_from_subreg_vert
-from TPTBox.core.vert_constants import Directions, Location, never_called, plane_dict, vert_directions
+from TPTBox.core.vert_constants import DIRECTIONS, Location, _plane_dict, never_called, vert_directions
 
 _log = Print_Logger()
 Vertebra_Orientation = tuple[np.ndarray, np.ndarray, np.ndarray]
@@ -160,8 +160,8 @@ def calc_orientation_of_vertebra_PIR(
         down_vector[reg_label] = normal_vector_post.copy()
         # create_plane_coords
         # The main axis will be treated differently
-        idx = [plane_dict[i] for i in subreg_iso.orientation]
-        axis = idx.index(plane_dict["S"])
+        idx = [_plane_dict[i] for i in subreg_iso.orientation]
+        axis = idx.index(_plane_dict["S"])
         # assert axis == np.argmax(np.abs(normal_vector)).item()
         dims = [0, 1, 2]
         dims.remove(axis)
@@ -245,7 +245,7 @@ def _make_spine_plot(pois: POI, body_spline, vert_nii: NII, filenames):
 
 
 ##### Extreme Points ####
-def _get_sub_array_by_direction(d: Directions, cords: np.ndarray) -> np.ndarray:
+def _get_sub_array_by_direction(d: DIRECTIONS, cords: np.ndarray) -> np.ndarray:
     """Get the sub-array of coordinates along a specified direction.
     cords must be in PIR direction
     Returns:
@@ -272,7 +272,7 @@ def _get_sub_array_by_direction(d: Directions, cords: np.ndarray) -> np.ndarray:
         never_called(d)
 
 
-def _get_direction(d: Directions, poi: POI, vert_id: int) -> np.ndarray:
+def _get_direction(d: DIRECTIONS, poi: POI, vert_id: int) -> np.ndarray:
     """Get the sub-array of coordinates along a specified direction.
     cords must be in PIR direction
     Returns:
@@ -300,7 +300,7 @@ def _get_direction(d: Directions, poi: POI, vert_id: int) -> np.ndarray:
         never_called(d)
 
 
-def get_extreme_point_by_vert_direction(poi: POI, region: NII, vert_id, direction: Sequence[Directions] | Directions = "I"):
+def get_extreme_point_by_vert_direction(poi: POI, region: NII, vert_id, direction: Sequence[DIRECTIONS] | DIRECTIONS = "I"):
     """
     Get the extreme point in a specified direction.
 
@@ -315,7 +315,7 @@ def get_extreme_point_by_vert_direction(poi: POI, region: NII, vert_id, directio
         Assumes `region` contains binary values indicating the presence of points.
         Uses `_get_sub_array_by_direction` internally.
     """
-    direction_: Sequence[Directions] = direction if isinstance(direction, Sequence) else (direction,)  # type: ignore
+    direction_: Sequence[DIRECTIONS] = direction if isinstance(direction, Sequence) else (direction,)  # type: ignore
 
     to_reference_frame, from_reference_frame = get_vert_direction_matrix(poi, vert_id=vert_id)
     pc = np.stack(np.where(region.get_array() == 1))
@@ -364,7 +364,7 @@ def strategy_extreme_points(
     poi: POI,
     current_subreg: NII,
     location: Location,
-    direction: Sequence[Directions] | Directions,
+    direction: Sequence[DIRECTIONS] | DIRECTIONS,
     vert_id: int,
     subreg_id: Location | list[Location],
     bb,
@@ -405,7 +405,7 @@ def strategy_line_cast(
     location: Location,
     start_point: Location,
     regions_loc: list[Location] | Location,
-    normal_vector_points: tuple[Location, Location] | Directions,
+    normal_vector_points: tuple[Location, Location] | DIRECTIONS,
     bb,
     log: Logger_Interface = _log,
 ):
@@ -424,7 +424,7 @@ def max_distance_ray_cast(
     region: NII,
     vert_id: int,
     bb: tuple[slice, slice, slice],
-    normal_vector_points: tuple[Location, Location] | Directions = "R",
+    normal_vector_points: tuple[Location, Location] | DIRECTIONS = "R",
     start_point: Location | np.ndarray = Location.Vertebra_Corpus,
     two_sided=False,
     log: Logger_Interface = _log,
@@ -459,7 +459,7 @@ def ray_cast(
     region: NII,
     vert_id: int,
     bb: tuple[slice, slice, slice],
-    normal_vector_points: tuple[Location, Location] | Directions = "R",
+    normal_vector_points: tuple[Location, Location] | DIRECTIONS = "R",
     start_point: Location | np.ndarray = Location.Vertebra_Corpus,
     log: Logger_Interface = _log,
     two_sided=False,
@@ -539,7 +539,7 @@ def strategy_ligament_attachment(
     bb,
     log=_log,
     corpus=None,
-    direction: Directions = "R",
+    direction: DIRECTIONS = "R",
     compute_arcus_points=False,
     do_shift=False,
 ):
@@ -572,8 +572,8 @@ def strategy_ligament_attachment(
 
     normal_vector = _get_direction(direction, poi, vert_id)
     # The main axis will be treated differently
-    idx = [plane_dict[i] for i in current_subreg.orientation]
-    axis = idx.index(plane_dict[direction])
+    idx = [_plane_dict[i] for i in current_subreg.orientation]
+    axis = idx.index(_plane_dict[direction])
     assert axis == np.argmax(np.abs(normal_vector)).item(), (axis, direction, normal_vector)
     dims = [0, 1, 2]
     dims.remove(axis)
@@ -908,8 +908,8 @@ def calc_center_spinal_cord(
         normal_vector /= np.linalg.norm(normal_vector)
         # create_plane_coords
         # The main axis will be treated differently
-        idx = [plane_dict[i] for i in subreg_iso.orientation]
-        axis = idx.index(plane_dict["S"])
+        idx = [_plane_dict[i] for i in subreg_iso.orientation]
+        axis = idx.index(_plane_dict["S"])
         # assert axis == np.argmax(np.abs(normal_vector)).item()
         dims = [0, 1, 2]
         dims.remove(axis)

--- a/TPTBox/mesh3D/mesh.py
+++ b/TPTBox/mesh3D/mesh.py
@@ -12,7 +12,7 @@ from skimage.measure import marching_cubes
 from TPTBox import NII, POI, Image_Reference, Log_Type, to_nii_seg
 from TPTBox.core import vert_constants as vc
 from TPTBox.core.np_utils import np_bbox_binary
-from TPTBox.core.poi import Coordinate
+from TPTBox.core.poi import COORDINATE
 
 log = vc.log
 logging = vc.logging
@@ -122,7 +122,7 @@ class POIMesh(Mesh3D):
         if subregions is None:
             subregions = poi.keys_subregion()
 
-        poi_extracted: list[Coordinate] = []
+        poi_extracted: list[COORDINATE] = []
 
         for r_id, s_id, coord in poi.items():
             if r_id in regions and s_id in subregions:

--- a/TPTBox/registration/ridged_intensity/register.py
+++ b/TPTBox/registration/ridged_intensity/register.py
@@ -25,7 +25,7 @@ Affine_Transforms = Literal["affine", "affine2d", "similarity", "similarity2d", 
 class HiddenPrints:
     def __enter__(self):
         self._original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, "w")  # noqa: SIM115
+        sys.stdout = open(os.devnull, "w")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout.close()

--- a/TPTBox/registration/ridged_intensity/register.py
+++ b/TPTBox/registration/ridged_intensity/register.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
     err.on_fail("This subscript needs nipy as an additonal package")
     err.on_fail("Please install: pip install nipy")
     sys.exit()
-from TPTBox import NII, Ax_Codes
+from TPTBox import AX_CODES, NII
 
 Similarity_Measures = Literal["slr", "mi", "pmi", "dpmi", "cc", "cr", "crl1"]
 Affine_Transforms = Literal["affine", "affine2d", "similarity", "similarity2d", "rigid", "rigid2d"]
@@ -25,7 +25,7 @@ Affine_Transforms = Literal["affine", "affine2d", "similarity", "similarity2d", 
 class HiddenPrints:
     def __enter__(self):
         self._original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, "w")
+        sys.stdout = open(os.devnull, "w")  # noqa: SIM115
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout.close()

--- a/TPTBox/registration/ridged_points/point_registration.py
+++ b/TPTBox/registration/ridged_points/point_registration.py
@@ -7,9 +7,9 @@ import numpy as np
 import SimpleITK as sitk  # noqa: N813
 
 from TPTBox import (
+    AX_CODES,
     NII,
     POI,
-    Ax_Codes,
     Image_Reference,
     Location,
     Log_Type,
@@ -34,7 +34,7 @@ class Point_Registration:
     _img_moving: sitk.Image
     _img_fixed: sitk.Image
     _transform: sitk.VersorRigid3DTransform
-    orientation: Ax_Codes
+    orientation: AX_CODES
     error_reg: float
     error_natural: float
     input_poi: POI

--- a/TPTBox/tests/test_utils.py
+++ b/TPTBox/tests/test_utils.py
@@ -15,7 +15,7 @@ import TPTBox.core.bids_files as bids  # noqa: E402
 from TPTBox import Centroids  # noqa: E402
 from TPTBox.core.nii_wrapper import NII  # noqa: E402
 from TPTBox.core.poi import POI  # noqa: E402
-from TPTBox.core.vert_constants import Ax_Codes  # noqa: E402
+from TPTBox.core.vert_constants import AX_CODES  # noqa: E402
 
 repeats = 20
 
@@ -81,7 +81,7 @@ def sqr1d(c1: float, w1: float, c2: float, w2: float):
     return True
 
 
-def get_random_ax_code() -> Ax_Codes:
+def get_random_ax_code() -> AX_CODES:
     directions = [["R", "L"], ["S", "I"], ["A", "P"]]
     idx = [0, 1, 2]
     random.shuffle(idx)

--- a/unit_tests/test_centroids_save.py
+++ b/unit_tests/test_centroids_save.py
@@ -14,13 +14,13 @@ import numpy as np
 
 import TPTBox.core.bids_files as bids
 from TPTBox import POI
-from TPTBox.core.nii_wrapper import NII, Ax_Codes
+from TPTBox.core.nii_wrapper import AX_CODES, NII
 from TPTBox.core.vert_constants import conversion_poi2text
 
 repeats = 20
 
 
-def get_random_ax_code() -> Ax_Codes:
+def get_random_ax_code() -> AX_CODES:
     directions = [["R", "L"], ["S", "I"], ["A", "P"]]
     idx = [0, 1, 2]
     random.shuffle(idx)

--- a/unit_tests/test_poi_global.py
+++ b/unit_tests/test_poi_global.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 
 import numpy as np
 
-from TPTBox import POI, Ax_Codes, POI_Global
+from TPTBox import AX_CODES, POI, POI_Global
 from TPTBox.core.poi_abstract import POI_Descriptor
 from TPTBox.tests.test_utils import get_poi, get_random_ax_code
 

--- a/unit_tests/test_slicing.py
+++ b/unit_tests/test_slicing.py
@@ -9,14 +9,14 @@ from pathlib import Path
 import nibabel as nib
 import numpy as np
 
-from TPTBox.core.nii_wrapper import NII, Ax_Codes
+from TPTBox.core.nii_wrapper import AX_CODES, NII
 from TPTBox.stitching import stitching_raw
 from TPTBox.tests.test_utils import overlap
 
 # TODO saving did not work with the test and I do not understand why.
 
 
-def get_random_ax_code() -> Ax_Codes:
+def get_random_ax_code() -> AX_CODES:
     directions = [["R", "L"], ["S", "I"], ["A", "P"]]
     idx = [0, 1, 2]
     random.shuffle(idx)

--- a/unit_tests/test_testsamples.py
+++ b/unit_tests/test_testsamples.py
@@ -86,7 +86,10 @@ class Test_testsamples(unittest.TestCase):
             poi = calc_poi_from_subreg_vert(vert_nii, subreg_nii, subreg_id=locs, verbose=False).extract_vert(vert_id)
             for l in locs:
                 self.assertIn((vert_id, l.value), poi)
-            poi.assert_affine(vert_nii)
+            poi.assert_affine(
+                vert_nii,
+                shape_tolerance=0.5,
+            )
 
     def test_POIs_CT(self):
         _, subreg_nii, vert_nii, label = get_test_ct()


### PR DESCRIPTION
- added POI.assert_affine()
- added convex hull functionality
- vert_constants now defines all terms used by both POI and NII (and are consistently capital letter)
- 